### PR TITLE
Feature: add custom project option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ unset(USE_FREERTOS CACHE)
 
 option(USE_FREERTOS "Enable FreeRTOS" OFF) # Turn this on to enable FreeRTOS
 
+# Use this option for custom LVGL project.
+option(USE_CUSTOM_PROJECT "Enable external custom LVGL project" OFF)
+
 if(USE_FREERTOS)
     message(STATUS "FreeRTOS is enabled")
 
@@ -187,4 +190,24 @@ if (ASAN)
 else()
     message(STATUS "AddressSanitizer disabled")
 endif()
+endif()
+
+# Conditionally include and link external LVGL project if USE_CUSTOM_PROJECT is enabled
+if (USE_CUSTOM_PROJECT)
+
+    set(CUSTOM_PROJECT_PATH "" CACHE PATH "Path to external custom LVGL project")
+
+    if(CUSTOM_PROJECT_PATH AND EXISTS "${CUSTOM_PROJECT_PATH}/CMakeLists.txt")
+        message(STATUS "Loading custom project from: ${CUSTOM_PROJECT_PATH}")
+
+        add_subdirectory("${CUSTOM_PROJECT_PATH}" "${CMAKE_BINARY_DIR}/custom_project")
+        if(TARGET custom_ui_lib)
+            target_link_libraries(main custom_ui_lib)
+            message(STATUS "Custom project loaded successfully")
+        else()
+            message(FATAL_ERROR "Target custom_ui_lib not found; ensure your custom project defines an alias named custom_ui_lib.")
+        endif()
+    else()
+         message(WARNING "USE_CUSTOM_PROJECT is ON but CUSTOM_PROJECT_PATH is invalid or CMakeLists.txt not found")
+    endif()
 endif()


### PR DESCRIPTION
## Description
The PR aims to add a new option simulate an external LVGL projects from LVGL Editor, for example. 
It's important to include this part in CMakeLists.txt in the LVGL Editor Project.
```
    add_library(custom_ui_lib ALIAS lib-ui)

    target_include_directories(lib-ui PUBLIC 
        ${CMAKE_CURRENT_SOURCE_DIR}
    )

    target_link_libraries(lib-ui PUBLIC lvgl)

    target_compile_definitions(lib-ui PUBLIC USE_CUSTOM_PROJECT)
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a CMake option to load and link an external custom LVGL project. This lets you simulate a UI project (e.g., from LVGL Editor) without changing this repo.

- **New Features**
  - Added USE_CUSTOM_PROJECT (OFF by default).
  - Configure CUSTOM_PROJECT_PATH to a project with a CMakeLists.txt; included via add_subdirectory.
  - Links custom_ui_lib to main and prints status/warnings for invalid paths.

- **Migration**
  - Enable with: -DUSE_CUSTOM_PROJECT=ON
  - Set path with: -DCUSTOM_PROJECT_PATH=/path/to/project

<!-- End of auto-generated description by cubic. -->

