### PR TITLE
docs(readme): fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is pre-configured for VSCode and should work work on Windows, Linux
 
 ### Install SDL and the build tools
 
-- **Windows (vcpkg):** `vcpkg install sdl2`  (`vcpkg` can be installed from [https://github.com/microsoft/vcpkg](https://github.com/microsoft/vcpkg)) Also install either MinGW or another compier and `cmake`.
+- **Windows (vcpkg):** `vcpkg install sdl2`  (`vcpkg` can be installed from [https://github.com/microsoft/vcpkg](https://github.com/microsoft/vcpkg)) Also install either MinGW or another compiler and `cmake`.
 - **macOS (Homebrew):** `brew install sdl2 cmake make`  
 - **Linux:**  
   - **Debian/Ubuntu:** `sudo apt install build-essential cmake libsdl2-dev`  


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed a typo in the README Windows (vcpkg) setup instructions: changed "compier" to "compiler" to clarify the setup steps.

<sup>Written for commit 22345903982154c16cb14023ca4d58ab88d6ca84. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

