### PR TITLE
Introduce the initial Windows backend integration support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,11 @@ endif()
 # Main include files of the project
 include_directories(${PROJECT_SOURCE_DIR}/main/inc)
 
-# Define options for LVGL with default values (OFF)
-option(LV_USE_DRAW_SDL "Use SDL draw unit" OFF)
+# Define options for LVGL with default values
+option(LV_USE_SDL "Use SDL backend." ON)
+if(LV_USE_SDL)
+    option(LV_USE_DRAW_SDL "Use SDL draw unit" OFF)
+endif()
 option(LV_USE_LIBPNG "Use libpng to decode PNG" OFF)
 option(LV_USE_LIBJPEG_TURBO "Use libjpeg turbo to decode JPEG" OFF)
 option(LV_USE_FFMPEG "Use libffmpeg to display video using lv_ffmpeg" OFF)
@@ -57,10 +60,14 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 # Find and include SDL2 library
-find_package(SDL2 REQUIRED)
+if(LV_USE_SDL)
+    find_package(SDL2 REQUIRED)
+endif()
 
 # Add compile definitions based on the selected options
-add_compile_definitions($<$<BOOL:${LV_USE_DRAW_SDL}>:LV_USE_DRAW_SDL=1>)
+if(LV_USE_SDL)
+    add_compile_definitions($<$<BOOL:${LV_USE_DRAW_SDL}>:LV_USE_DRAW_SDL=1>)
+endif()
 add_compile_definitions($<$<BOOL:${LV_USE_LIBPNG}>:LV_USE_LIBPNG=1>)
 add_compile_definitions($<$<BOOL:${LV_USE_LIBJPEG_TURBO}>:LV_USE_LIBJPEG_TURBO=1>)
 add_compile_definitions($<$<BOOL:${LV_USE_FFMPEG}>:LV_USE_FFMPEG=1>)
@@ -145,13 +152,18 @@ add_executable(main ${MAIN_SOURCES})
 target_compile_definitions(main PRIVATE LV_CONF_INCLUDE_SIMPLE)
 target_link_libraries(main ${MAIN_LIBS})
 
-# On Windows, GUI applications do not show a console by default,
-# which hides log output. This ensures a console is available for logging.
 if (WIN32)
+    # On Windows, GUI applications do not show a console by default,
+    # which hides log output. This ensures a console is available for logging.
     if (MSVC)
         target_link_options(main PRIVATE "/SUBSYSTEM:CONSOLE")
     else()
         target_link_options(main PRIVATE "-mconsole")
+    endif()
+    # On MSVC, we also need to enable some compiler options for UTF-8 support.
+    if (MSVC)
+        target_compile_options(lvgl PRIVATE "/utf-8")
+        target_compile_options(main PRIVATE "/utf-8")
     endif()
 endif()
 
@@ -159,6 +171,7 @@ endif()
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(STATUS "Debug mode enabled")
 
+if(NOT MSVC)
     target_compile_options(lvgl PRIVATE
         -pedantic-errors
         -Wall
@@ -184,6 +197,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         -Wfloat-conversion
         -Wstrict-aliasing
     )
+endif()
 
 if (ASAN)
     message(STATUS "AddressSanitizer enabled")

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ by enabling the same flag from the command line when bootstrapping `cmake`:
 cmake -B build -DUSE_FREERTOS=ON
 ```
 
+### Notes for enabling Windows backend
+
+> [!NOTE]
+> It's recommended to use this mode when you using Visual Studio (not Code)
+> CMake support.
+
+First, make sure turning off the SDL driver for CMake configuration by adding
+`-DLV_USE_SDL=OFF` flag when bootstrapping `cmake`:
+
+```
+cmake -B build -DLV_USE_SDL=OFF
+```
+
+Then, set following defines in `lv_conf.h`:
+
+- `#define LV_USE_OS   LV_OS_NONE` to `#define LV_USE_OS   LV_OS_WINDOWS`
+- `#define LV_USE_SDL              1` to `#define LV_USE_SDL              0`
+- `#define LV_USE_WINDOWS    0` to `#define LV_USE_WINDOWS    1`
+
 ### CMake
 
 This project uses CMake under the hood which can be used without Visula Studio Code too. Just type these in a Terminal when you are in the project's root folder:

--- a/src/hal/hal.c
+++ b/src/hal/hal.c
@@ -1,6 +1,6 @@
 #include "hal.h"
 
-
+#if LV_USE_SDL
 lv_display_t * sdl_hal_init(int32_t w, int32_t h)
 {
 
@@ -32,3 +32,29 @@ lv_display_t * sdl_hal_init(int32_t w, int32_t h)
 
   return disp;
 }
+#endif
+
+#if LV_USE_WINDOWS
+lv_display_t* win_hal_init(
+    const wchar_t* title,
+    int32_t hor_res,
+    int32_t ver_res,
+    int32_t zoom_level,
+    bool allow_dpi_override,
+    bool simulator_mode)
+{
+    lv_display_t* display = lv_windows_create_display(
+        title,
+        hor_res,
+        ver_res,
+        zoom_level,
+        allow_dpi_override,
+        simulator_mode);
+
+    lv_windows_acquire_pointer_indev(display);
+    lv_windows_acquire_keypad_indev(display);
+    lv_windows_acquire_encoder_indev(display);
+
+	return display;
+}
+#endif

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -27,11 +27,27 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
+#if LV_USE_SDL
 /**
  * Initialize the Hardware Abstraction Layer (HAL) for the LVGL graphics
  * library
  */
 lv_display_t * sdl_hal_init(int32_t w, int32_t h);
+#endif
+
+#if LV_USE_WINDOWS
+/**
+ * Initialize the Hardware Abstraction Layer (HAL) for the LVGL graphics
+ * library
+ */
+lv_display_t* win_hal_init(
+    const wchar_t* title,
+    int32_t hor_res,
+    int32_t ver_res,
+    int32_t zoom_level,
+    bool allow_dpi_override,
+    bool simulator_mode);
+#endif
 
 /**********************
  *      MACROS

--- a/src/main.c
+++ b/src/main.c
@@ -22,7 +22,9 @@
 #include "lvgl/lvgl.h"
 #include "lvgl/examples/lv_examples.h"
 #include "lvgl/demos/lv_demos.h"
-#include <SDL.h>
+#if LV_USE_SDL
+  #include <SDL.h>
+#endif
 
 #include "hal/hal.h"
 
@@ -61,7 +63,21 @@ int main(int argc, char **argv)
   lv_init();
 
   /*Initialize the HAL (display, input devices, tick) for LVGL*/
+#if LV_USE_SDL
   sdl_hal_init(320, 480);
+#endif
+#if LV_USE_WINDOWS
+  int32_t zoom_level = 100;
+  bool allow_dpi_override = false;
+  bool simulator_mode = true;
+  win_hal_init(
+      L"LVGL Display", 
+      320, 
+      480, 
+      zoom_level,
+      allow_dpi_override, 
+      simulator_mode);
+#endif
 
   /* Run the default demo */
   /* To try a different demo or example, replace this with one of: */
@@ -79,7 +95,11 @@ int main(int argc, char **argv)
 	sleep_time_ms =  LV_DEF_REFR_PERIOD;
     }
 #ifdef _MSC_VER
+#if LV_USE_WINDOWS
+    lv_delay_ms(sleep_time_ms);
+#else
     Sleep(sleep_time_ms);
+#endif
 #else
     usleep(sleep_time_ms * 1000);
 #endif


### PR DESCRIPTION
I think we should add Visual Studio (not Code) CMake adaption to this repo as my reply of https://github.com/lvgl/lv_port_pc_visual_studio/issues/114.

This is the first step to achieve this goal.

Maybe the future steps we need:

- Have a CMakePresets.json for common CMake targets which supported by this repo.
- Do some further improvement for lv_conf related things to reduce the manually modifications for lv_conf.

Kenji Mouri

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Windows backend so LVGL can run without SDL in Visual Studio CMake builds. This is the first step toward full Windows support.

- **New Features**
  - Windows HAL: adds win_hal_init to create a Windows display and set up pointer, keypad, and encoder input devices.
  - main.c: conditional init for SDL vs Windows; uses lv_delay_ms on MSVC when Windows backend is active.
  - CMake: new LV_USE_SDL option (default ON); conditionally finds SDL and sets draw-unit defines; adds Windows console subsystem and MSVC /utf-8 compiler flags; guards non-MSVC warning options.
  - README: adds instructions to enable the Windows backend.

- **Migration**
  - Disable SDL: cmake -B build -DLV_USE_SDL=OFF
  - Update lv_conf.h:
    - LV_USE_OS to LV_OS_WINDOWS
    - LV_USE_SDL to 0
    - LV_USE_WINDOWS to 1

<sup>Written for commit 93fb55f988bae239f0995764eaff58115cceb10c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

